### PR TITLE
Small (but useful) fixes

### DIFF
--- a/backend/src/main/java/no/ntnu/database/jwt/SecurityConfiguration.java
+++ b/backend/src/main/java/no/ntnu/database/jwt/SecurityConfiguration.java
@@ -75,9 +75,9 @@ public class SecurityConfiguration {
 						.requestMatchers(HttpMethod.GET,
 								"/categories", "/categories/{query}",
 								"/courses", "/courses/{id}", "/courses/search/{query}",
-								"/providers", "/providers/{id}", "/providers/search/{query}",
-                                "/favorites", "/favorites/{int}", "/favorites/{id}"
+								"/providers", "/providers/{id}", "/providers/search/{query}"
 						).permitAll()
+                        .requestMatchers("/favorites/**").hasAnyAuthority("ROLE_USER", "ROLE_ADMIN")
                         .requestMatchers("/admin/users/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/")
                         .permitAll() // The default URL/is accessible to everyone

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,6 +20,8 @@ import Footer from './components/Footer.vue';
 
 // import function to register Swiper custom elements
 import { register } from 'swiper/element/bundle';
+import { store } from './utility/store';
+import { getCookie } from './utility/cookieHelper';
 // register Swiper custom elements
 register();
 
@@ -29,6 +31,12 @@ export default {
   components: {
     TopToolbar,
     Footer
+  },
+  setup() {
+    const jwt = getCookie("authToken");
+    if (jwt) {
+      store.login(getCookie("authToken"));
+    }
   },
   data() {
     return { lastClick: null }

--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -54,9 +54,7 @@ export default {
           username: this.email,
           password: this.password
         });
-
-        const decoded = jwtDecode(response.data.jwt);
-        store.login(response.data.jwt, decoded.roles);
+        const decoded = store.login(response.data.jwt);
         console.log('Decoded JWT:', decoded);
         this.$emit('login-success', { user: decoded.sub, roles: decoded.roles });
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,13 +2,39 @@ import { createApp } from 'vue'
 import { registerPlugins } from '@/plugins'
 import App from './App.vue'
 import router from './router';
+import { store } from './utility/store';
+import { getCookie } from './utility/cookieHelper';
 
 const courseApp = createApp(App)
 courseApp.config.globalProperties.$backendUrl = "http://localhost:8080/";
+courseApp.config.globalProperties.$authFetch = async function (endpoint, requestData) {
+    const jwt = getCookie("authToken");
+    let response;
+    if (store.user.isLoggedIn && jwt) {
+        if (requestData == null) {
+            requestData = { headers: {} };
+        } else if (requestData.headers == null) {
+            requestData.headers = {};
+        }
+        requestData.headers.Authorization = "Bearer " + jwt;
+        response = await fetch(endpoint, requestData);
+    } else {
+        response = null;
+    }
+    return response;
+}
+courseApp.config.globalProperties.$authFetchOrPromptLogin = async function (endpoint, requestData) {
+    const response = await this.$authFetch(endpoint, requestData);
+    if (response == null || response.status == 403) {
+        store.logout();
+        this.$router.push("/login");
+    }
+    return response;
+}
 
 registerPlugins(courseApp)
 
 
 
 courseApp.use(router)
-.mount('#app');
+    .mount('#app');

--- a/frontend/src/pages/CoursePage.vue
+++ b/frontend/src/pages/CoursePage.vue
@@ -154,7 +154,7 @@ export default {
 }
 
 /* Adjustments specifically for mobile devices */
-@media screen and (max-width: 479px) {
+@media screen and (max-width: 600px) {
 	.course-title {
 		font-size: 1.5em;
 	}
@@ -179,6 +179,9 @@ export default {
 	.info-buttons .v-btn {
 		margin: 2px 4px;
 	}
+	.info-buttons {
+		flex-wrap: wrap;
+	}
 }
 
 .info-buttons {
@@ -188,7 +191,7 @@ export default {
 	max-width: 80%;
 	margin: 0 auto;
 	margin-top: 10px;
-	flex-wrap: wrap;
+	gap: 5px;
 }
 
 .course-title {

--- a/frontend/src/pages/SearchResults.vue
+++ b/frontend/src/pages/SearchResults.vue
@@ -31,11 +31,7 @@ export default {
 	methods: {
 		selectResult(result) {
 			if (result.type == "course") {
-				const query = new URLSearchParams();
-				query.append("id", result.courseId);
-				if (query.get("id")) {
-					location.href = "./course?" + query.toString();
-				}
+				this.$router.push("/course/" + result.id);
 			} else if (result.type == "provider") {
 				if (result.url) {
 					location.href = result.url;

--- a/frontend/src/utility/store.js
+++ b/frontend/src/utility/store.js
@@ -1,16 +1,21 @@
 import { reactive } from 'vue';
 import { setCookie,  deleteCookie } from '../utility/cookieHelper';
+import { jwtDecode } from 'jwt-decode';
 
 export const store = reactive({
     user: {
       isLoggedIn: false,
       roles: []
     },
-    login(jwt, roles = []) {
+    login(jwt) {
+      const decoded = jwtDecode(jwt);
+
       this.user.isLoggedIn = true;
-      this.user.roles = roles;
+      this.user.roles = decoded.roles;
       localStorage.setItem('isLoggedIn', 'true');
       setCookie('authToken', jwt, 1);
+
+      return decoded;
     },
     logout() {
       this.user.isLoggedIn = false;


### PR DESCRIPTION
This branch is done now, these are the last changes added to it

- Refreshing retains login state, so you can refresh the favorites page without being redirected to the login screen
- Search results properly works with dynamic courses
- Fallback text if a course has no providers
- `/favorite`-endpoints now require user authentication (previously required none)
- `fetch(...)` with auth token stored in cookies has been made into a global method
- course page now properly formats time