### PR TITLE
Hide sale

### DIFF
--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -8,7 +8,8 @@
 
 		<!-- Any other sections we want on the homepage -->
 		<section class="Carousel test">
-			<CourseCarousel :courses="courses" difficulty="Sale"/>
+			<!-- Sales got broken due to editing via admin panel last minute, so they are commented out for now.-->
+			<!--<CourseCarousel :courses="courses" difficulty="Sale"/>--> 
 			<CourseCarousel :courses="courses" difficulty="Beginner"/>
 			<CourseCarousel :courses="courses" difficulty="Intermediate"/>
 			<CourseCarousel :courses="courses" difficulty="Expert"/>


### PR DESCRIPTION
I did some last minute editing of descriptions, and apparently due to sale not being defined it broke the featured category. So they are now hidden to not show the empty featured. 